### PR TITLE
Use uploaded JPG banner on About page

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <link rel="manifest" href="/assets/favicon/site.webmanifest" />
 
   <!-- Preload the hero so it downloads immediately -->
-  <link rel="preload" as="image" href="/assets/matchabanner.png" />
+  <link rel="preload" as="image" href="/assets/matchabanner.jpg" />
 
   <style>
     :root{
@@ -97,7 +97,7 @@
   <!-- Hero banner -->
   <div class="banner-frame">
     <img
-      src="/assets/matchabanner.png"
+      src="/assets/matchabanner.jpg"
       alt="Matcha in Paris banner"
       class="banner-img"
       loading="eager" fetchpriority="high" decoding="async">


### PR DESCRIPTION
### Motivation
- Swap the About page hero from the existing PNG to the newly uploaded JPG so the page uses the provided `matchabanner.jpg` asset.

### Description
- Updated `index.html` to replace `/assets/matchabanner.png` with `/assets/matchabanner.jpg` in both the preload link and the hero `<img>` `src`.

### Testing
- Served the site with `python3 -m http.server 4173` and ran a Playwright script that loaded `http://127.0.0.1:4173/index.html` and captured `artifacts/about-banner-jpg.png`, and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b3b3ca87c8320b964bfd7937c25ea)