### PR TITLE
Align About text card boundaries with banner on web and mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
   <style>
     :root{
       --content: 1200px;
+      --banner-max: 1080px;
       --logo-height: clamp(200px, 22vw, 320px);
     }
 
@@ -47,17 +48,15 @@
 
     /* Wider banner */
     .banner-frame{
-      max-width:var(--content);
+      max-width:calc(var(--banner-max) + 32px);
       margin:8px auto 20px;
       padding:0 16px
     }
 
-    /* Cap height, keep full width, crop nicely */
+    /* Keep full image visible without cropping */
     .banner-img{
       width:100%;
-      height: clamp(200px, 26vmin, 360px);
-      object-fit: cover;
-      object-position:center 45%;
+      height:auto;
       border-radius:12px;
       display:block;
       background:#dfe8d6;
@@ -65,7 +64,7 @@
 
     /* About content width */
     .container{
-      max-width:var(--content);
+      max-width:calc(var(--banner-max) + 32px);
       margin:0 auto;
       padding:0 16px;
     }


### PR DESCRIPTION
### Motivation
- Make the text card below the hero banner use the exact same horizontal boundaries as the banner across breakpoints so the card visually lines up with the photo on both desktop and mobile. 
- Preserve the banner image's full visible area and original aspect ratio so it never crops important content.

### Description
- Added a shared CSS variable `--banner-max` and used it to compute the frame widths with `max-width: calc(var(--banner-max) + 32px)` for both `.banner-frame` and `.container` in `index.html`.
- Changed `.banner-img` to render uncropped with `width: 100%` and `height: auto` and removed the previous `object-fit` / capped height behavior so the full image is visible.
- Adjusted layout so the banner and the following content share the same maximum width calculation, keeping gutters via the existing `padding: 0 16px`.

### Testing
- Started a local static server with `python3 -m http.server 4173` and verified the page served successfully. 
- Ran a Playwright script to capture screenshots at desktop (`1440x1100`) and mobile (`390x844`) viewports and confirmed the banner and text card align in both screenshots.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b3dda80c083208e41f35bdfccc047)