### PR TITLE
Resize homepage banner to be smaller while preserving aspect ratio

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <style>
     :root{
       --content: 1200px;
-      --banner-max: 1080px;
+      --banner-max: 820px;
       --logo-height: clamp(200px, 22vw, 320px);
     }
 


### PR DESCRIPTION
### Motivation
- Reduce the visual width of the homepage banner so it appears smaller across viewports while ensuring no cropping and preserving its original aspect ratio.

### Description
- Updated `index.html` to change CSS variable `--banner-max` from `1080px` to `820px`, keeping the existing responsive rules (`.banner-img { width: 100%; height: auto; }`) so the image scales proportionally.

### Testing
- Started a local server with `python3 -m http.server --directory /workspace/matchainparis 4173`, loaded `http://localhost:4173/index.html` and captured a screenshot via Playwright for visual verification, and ran `git diff --check` before committing; all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b427887b4832085fbc1b364361126)